### PR TITLE
Fix to select only 2020 sessions in 2020 program

### DIFF
--- a/2020/program.md
+++ b/2020/program.md
@@ -97,7 +97,7 @@ year: 2020
 
 
 <div id="program" class="row-xs-12">
-{% assign sessions = site.session | sort: 'start' %}
+{% assign sessions = site.session |  where: "year", "2020" | sort: 'start' %}
 {% assign allTalks = site.data.talks[year]  | sort: 'talk_id' %}
 
 {% for mySession in sessions %}


### PR DESCRIPTION
Without this, the 2020 program adds a list of the 2021 sessions too with a bad date formatting.